### PR TITLE
Update .gitbook.yaml

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,4 +1,5 @@
 root: ./
 
 redirects:  
-    whereby-embedded-sdk-beta: README.md
+    # whereby-embedded-sdk-beta: README.md
+    embedding-rooms: whereby-101/in-a-web-page


### PR DESCRIPTION
remove readme redirect as it unexpectedly added 'readme' to all URLs. 

Added a redirect of old broken link