### PR TITLE
List the summary template in the /POST summaries endpoint

### DIFF
--- a/.gitbook/assets/_api-reference-docs-openapi.json
+++ b/.gitbook/assets/_api-reference-docs-openapi.json
@@ -1029,7 +1029,7 @@
                       "Educational Lecture",
                       "Educational Tutoring"
                     ],
-                    "description": "The template that the summary should be created from. \n",
+                    "description": "The template that the summary should be created from. The following summary templates are currently available:\n- `General Bulleted`\n- `General Narrative`\n- `SOAP`\n- `Extended SOAP`\n- `General Narrative`\n- `Educational Lecture`\n- `Educational Tutoring` \n",
                     "example": "General Narrative"
                   }
                 }


### PR DESCRIPTION
Updated the template description to list the template types that are currently available ✨ 

(Taken from [here](https://docs.whereby.com/meeting-content-and-quality/recording-and-streaming-rooms/transcribing-sessions-1#summary-templates))