### PR TITLE
Add room name to get transcriptions endpoint

### DIFF
--- a/.gitbook/assets/_api-reference-docs-openapi.json
+++ b/.gitbook/assets/_api-reference-docs-openapi.json
@@ -924,6 +924,14 @@
         "parameters": [
           {
             "in": "query",
+            "name": "roomName",
+            "schema": {
+              "type": "string",
+              "description": "The name of the room"
+            }
+          },
+          {
+            "in": "query",
             "name": "cursor",
             "schema": {
               "type": "string",


### PR DESCRIPTION
The roomName query param is currently missing in the documentation.