### PR TITLE
Add github readme

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,6 @@
+# Whereby Embedded Docs
+
+Documentation for Whereby Embedded — the easiest way to add video calls
+to your web page or mobile app.
+
+👉 [View the docs](https://docs.whereby.com)


### PR DESCRIPTION
Gitbook automagically pushes their homepage to the README for this repo - but it contains gitbook specific formatting that doesn't make sense here. Let's add a basic README for anyone landing here - without interfering with the landing page in gitbook. 